### PR TITLE
fix(square): transform pollItems and canMultiple in body

### DIFF
--- a/src/square/entity/square.entity.ts
+++ b/src/square/entity/square.entity.ts
@@ -16,11 +16,7 @@ export const CommentZodSchema = z.object({
 });
 
 export const PollItemZodSchema = z.object({
-  _id: z.string().regex(/^[0-9a-fA-F]{24}$/, 'Invalid MongoDB ObjectId'),
   name: z.string(),
-  users: z.array(
-    z.string().regex(/^[0-9a-fA-F]{24}$/, 'Invalid MongoDB ObjectId'),
-  ),
 });
 
 export const SecretSquareZodSchema = z.object({

--- a/src/square/square.controller.ts
+++ b/src/square/square.controller.ts
@@ -13,6 +13,8 @@ import {
   HttpStatus,
   Put,
   Inject,
+  Injectable,
+  PipeTransform,
 } from '@nestjs/common';
 import { FilesInterceptor } from '@nestjs/platform-express';
 import { memoryStorage } from 'multer';
@@ -22,6 +24,17 @@ import { ISquareService } from './squareService.interface';
 import { ISQUARE_SERVICE } from 'src/utils/di.tokens';
 
 // DTOs for request validation
+
+@Injectable()
+export class ValidationPipe implements PipeTransform {
+  transform(value: any) {
+    return {
+      ...value,
+      pollItems: JSON.parse(value.pollItems),
+      canMultiple: JSON.parse(value.canMultiple),
+    };
+  }
+}
 
 @Controller('square')
 export class SquareController {
@@ -51,7 +64,7 @@ export class SquareController {
   @UseInterceptors(FilesInterceptor('images', 5, { storage: memoryStorage() }))
   async createSquare(
     @UploadedFiles() files: Express.Multer.File[],
-    @Body() createSquareDto: CreateSquareDto,
+    @Body(new ValidationPipe()) createSquareDto: CreateSquareDto,
   ) {
     const buffers: Buffer[] = files ? files.map((file) => file.buffer) : [];
 

--- a/src/square/square.repository.interface.ts
+++ b/src/square/square.repository.interface.ts
@@ -7,7 +7,7 @@ export interface SquareRepository {
     gap: number,
   ): Promise<SecretSquareItem[]>;
   create(squareData: any): Promise<SecretSquareItem>;
-  findByIdAndDelete(quareId: string): Promise<null>;
+  findByIdAndDelete(squareId: string): Promise<null>;
   findByIdAndUpdate(squareId: string, userId: string): Promise<null>;
   findByIdCustom(squareId: string, userId): Promise<SecretSquareItem>;
   updateComment(
@@ -27,7 +27,7 @@ export interface SquareRepository {
   ): Promise<null>;
   deleteSubComment(
     squareId: string,
-    commentId: String,
+    commentId: string,
     subCommentId: string,
   ): Promise<null>;
   updateSubComment(

--- a/src/square/square.service.ts
+++ b/src/square/square.service.ts
@@ -102,11 +102,6 @@ export default class SquareService implements ISquareService {
             images,
           });
 
-    if (squareType === 'poll') {
-      const { _id: squareId } = await this.SecretSquare.create(validatedSquare);
-      return { squareId };
-    }
-
     const { _id: squareId } = await this.SecretSquare.create(validatedSquare);
     return { squareId };
   }


### PR DESCRIPTION
## PR Points
> nest 에서 제시하는 아키텍처가 처음이라 공식문서 보면서 해결해봤어요

`controller` 역할이 express의 route 역할을 해주는거로 파악이 되는데요. **캡쳐에서 dto의 `pollItems`와 `canMultiple`로 들어오는 값이 문자열로 들어가고 있어요.** 그래서 zod에서 에러를 뿜는 거로 확인이 됩니다
즉, `pollItems`와 `canMultiple` 값이 문자열로 요청 body가 들어와서 각각 배열과 boolean으로 파싱해주는 로직이 필요했어요. **저는 [ValidationPipe 커스텀 파이프](https://docs.nestjs.com/pipes#custom-pipes) 만들어서 해결했는데, 다른 방법도 있나요?**

![image](https://github.com/user-attachments/assets/49f29c59-5ad6-4c3a-b1c0-fd8fe5cf6d26)
